### PR TITLE
F/2098/generalize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 *.tfstate*
 *.tfvars
 envs/
+__backend__.tf
+.nullstone/active-workspace.yml

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -48,26 +48,22 @@ provider "registry.terraform.io/hashicorp/random" {
 }
 
 provider "registry.terraform.io/nullstone-io/ns" {
-  version = "0.6.24"
+  version = "0.7.0"
   hashes = [
-    "h1:ORFNEXgv7Pvt8sBS51xL1/ZNYMnAHUo+jRXbz02CRdM=",
-    "h1:XizFYcjQm2TE+uPfv2XGlJteYVMJr22SjkMZb13mCPE=",
-    "h1:ipu82tc68+Mv147lqIEUNzKwGovK7wxnkruPy6X28vU=",
-    "h1:j8PUFGXZmsmYsUaWDVa4AhEfkselQKGJe/lEBsIbxhM=",
-    "h1:vgcMQsOCNtc9AgUSv1CYuslAxfA931o4qp4egsSde8M=",
-    "zh:0afca196adbfcec7dc76edc2307789c518f6bee47eabd5478e0ec76e92e5686c",
-    "zh:19c6bdf2f5e9d478420afc88fe0a77750d78481bb9a7466c09e3c8c0df168eb3",
-    "zh:38ea4dde252b6b232132d8bd5e8b9c9be65aabdb813f999403eeff043bab0d77",
-    "zh:3e1467b17bc72b62286a8fb6416d8448f32a1c0c5d562b5f0d9ee65e87e61772",
-    "zh:49ceac32a976ba8288d0861bc06be0c934a8cb321c5b6c9e2aba01f743d6a89c",
-    "zh:5050ecd840577990a769d2d6a1175fe21fba8a9698b0444fe18b5f5ce4a5bbf7",
-    "zh:64752162f4aaf58ee078ec66ce05458ee800152839221adb966650d1cdcfbb78",
-    "zh:7624c5ab46b0b05669e203629d6d8a159da64c3bc1084971bba29cf57c919e1c",
-    "zh:90ec9f7501567840298636254eb9a1f2698bf6e3cdc0bed6d880bca2193183d0",
-    "zh:b63aaebc716190f58981e7de7469409e2795612b63d79813e6c7285f9bd7a942",
-    "zh:cd0e6ceaacd6f015892be49d60a66e235b8b4b7fad31ce17228c8978a5bb432f",
-    "zh:d6371972cd5c544ad2203ec9199dd044984e33d73efb52020c617dae84c75131",
-    "zh:f7d79b7c05d6da017a7d999ec34d494d96d2f8513f0aefc794b243494111ba5b",
-    "zh:fe5b68873f10aa3beda063528a4767117925d713302a2bed8529de886c1a11bd",
+    "h1:RN1sdfnqtprye/jOqvFrO49j/HX4ZEjiG35PC7pEVB8=",
+    "zh:1b1a2a63fb533c6b679bab2bfd9d02cd4fabbe3102c7fedd470f8f82be626acd",
+    "zh:2d9d8adb26b1ba0448e184849b632fef4dc208bd95abdf61e51de87fecd91211",
+    "zh:2f8558c2dd24ea2a9b27ccbe540877e7b65c98d6e83dc74c64a4cfa764ead6e6",
+    "zh:3a9317f202349c514ec9e8f3dcb388634ce209ca05fec3b65602cb27d9c435c6",
+    "zh:413d21bb6bcb3ea89b9a4e707d34af41dad89f5b24da9917f7941b12fd9311fc",
+    "zh:4b1ebd1b87373361e5dab0e9e2abceeea383af61d9b117d9949fe1d583e5f3f0",
+    "zh:505d23ace1cc4e252de9416fe94e5226c50c87b3172eff7685512bc3bb537f5a",
+    "zh:5b3f9807af49b2574f40afda5e954d68ee40c5e4b3cccd92006c1208ad519ee9",
+    "zh:7071412f03cafe5580ff458b625e4799e00bc73a397b9cc9d0a39fd644ac8ac7",
+    "zh:74bbb49083e29cac04980c956697d81f6ac224b53f42624ae459b35b98ff590b",
+    "zh:800c24bc63ff751053a842675c473ea50c18e2b1ee973fa33cf676ad0b1e6b64",
+    "zh:c213b39546922f45ed6f60d69556d6cc7fd5420cd0894c7e3dc24842fad139ab",
+    "zh:c950c29a144ba5588940c0061bcd7874985b8d983bd9f572e60a0755cc59862c",
+    "zh:e93b9750d1ca9e95909c38e358721f93e7cc31dd40d987860de3de51968b618d",
   ]
 }

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,73 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "6.13.0"
+  hashes = [
+    "h1:+2T5mGN0JeFWxrQx+WVSR+H8+oCY943zmNEVc/Cz1j4=",
+    "h1:K01g96E7e30a7ydomvB2PgH82UtXRCbzRW2qtt0yyb8=",
+    "h1:PpxlbsdUC7HBfbMHGc6A7bWNbCtAl0BnZyplFRNvU8A=",
+    "h1:YiSOZFsdpzXgRN5NB01Fzfs8mvAlTnrM85/QktOhmgw=",
+    "h1:jakE2O6gqqQHIZYnr4K7zCNqlMDO/VMgVbCPbbLT/Oc=",
+    "zh:05067a572a2fcec7ab2e613611db68ff9fdaac18869f76ca53ce308f8f4b904a",
+    "zh:1122fae676ba52d4842267ce8a9e391c262d2468c095b6ad7b0550c1bf292b05",
+    "zh:1cde30b75d4e5ecd8eabcf2f9119302611a2b757f9cd50474c21f30dba77dd60",
+    "zh:444d333a8af09d4f561a09c56eee48cd23e97fca94c427ae5e4a24745418a097",
+    "zh:471303b121adf8b9225de70127f62f3b96033a9ab6e14f9dc7fe19f6d224186d",
+    "zh:4caa73ea78c85dc4abde022d114d4d2ff770636def8f308472e3679ac5195d9a",
+    "zh:6257a064015ed1c277cfb39027b91de2b7bc6f1ce6d42058b9df3d5aa37ecb4f",
+    "zh:8a45fe7f3e4b10ba6e8c5e44fecd0c7389e6f9c8cca11d052a357fbaae615c1a",
+    "zh:8ce6902473efdf92724679c2b63905263d83dcf77bd8d9e9f45701cdc9dcc229",
+    "zh:ce8951ef5ce96d694f7fbcea6d7dd593f6102b3ac1c686e03f08316dd7923d2d",
+    "zh:ef009b465067b8d3646d0c6ca8a6ba860d4591ddc427f005cfa5d4fcac0c4fce",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.6.3"
+  hashes = [
+    "h1:+UItZOLue/moJfnI3tqZBQbXUYR4ZnqPYfJDJPgLZy0=",
+    "h1:Fnaec9vA8sZ8BXVlN3Xn9Jz3zghSETIKg7ch8oXhxno=",
+    "h1:In4XBRMdhY89yUoTUyar3wDF28RJlDpQzdjahp59FAk=",
+    "h1:f6jXn4MCv67kgcofx9D49qx1ZEBv8oyvwKDMPBr0A24=",
+    "h1:zG9uFP8l9u+yGZZvi5Te7PV62j50azpgwPunq2vTm1E=",
+    "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
+    "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",
+    "zh:4b4c11ccfba7319e901df2dac836b1ae8f12185e37249e8d870ee10bb87a13fe",
+    "zh:4fa45c44c0de582c2edb8a2e054f55124520c16a39b2dfc0355929063b6395b1",
+    "zh:588508280501a06259e023b0695f6a18149a3816d259655c424d068982cbdd36",
+    "zh:737c4d99a87d2a4d1ac0a54a73d2cb62974ccb2edbd234f333abd079a32ebc9e",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a357ab512e5ebc6d1fda1382503109766e21bbfdfaa9ccda43d313c122069b30",
+    "zh:c51bfb15e7d52cc1a2eaec2a903ac2aff15d162c172b1b4c17675190e8147615",
+    "zh:e0951ee6fa9df90433728b96381fb867e3db98f66f735e0c3e24f8f16903f0ad",
+    "zh:e3cdcb4e73740621dabd82ee6a37d6cfce7fee2a03d8074df65086760f5cf556",
+    "zh:eff58323099f1bd9a0bec7cb04f717e7f1b2774c7d612bf7581797e1622613a0",
+  ]
+}
+
+provider "registry.terraform.io/nullstone-io/ns" {
+  version = "0.6.24"
+  hashes = [
+    "h1:ORFNEXgv7Pvt8sBS51xL1/ZNYMnAHUo+jRXbz02CRdM=",
+    "h1:XizFYcjQm2TE+uPfv2XGlJteYVMJr22SjkMZb13mCPE=",
+    "h1:ipu82tc68+Mv147lqIEUNzKwGovK7wxnkruPy6X28vU=",
+    "h1:j8PUFGXZmsmYsUaWDVa4AhEfkselQKGJe/lEBsIbxhM=",
+    "h1:vgcMQsOCNtc9AgUSv1CYuslAxfA931o4qp4egsSde8M=",
+    "zh:0afca196adbfcec7dc76edc2307789c518f6bee47eabd5478e0ec76e92e5686c",
+    "zh:19c6bdf2f5e9d478420afc88fe0a77750d78481bb9a7466c09e3c8c0df168eb3",
+    "zh:38ea4dde252b6b232132d8bd5e8b9c9be65aabdb813f999403eeff043bab0d77",
+    "zh:3e1467b17bc72b62286a8fb6416d8448f32a1c0c5d562b5f0d9ee65e87e61772",
+    "zh:49ceac32a976ba8288d0861bc06be0c934a8cb321c5b6c9e2aba01f743d6a89c",
+    "zh:5050ecd840577990a769d2d6a1175fe21fba8a9698b0444fe18b5f5ce4a5bbf7",
+    "zh:64752162f4aaf58ee078ec66ce05458ee800152839221adb966650d1cdcfbb78",
+    "zh:7624c5ab46b0b05669e203629d6d8a159da64c3bc1084971bba29cf57c919e1c",
+    "zh:90ec9f7501567840298636254eb9a1f2698bf6e3cdc0bed6d880bca2193183d0",
+    "zh:b63aaebc716190f58981e7de7469409e2795612b63d79813e6c7285f9bd7a942",
+    "zh:cd0e6ceaacd6f015892be49d60a66e235b8b4b7fad31ce17228c8978a5bb432f",
+    "zh:d6371972cd5c544ad2203ec9199dd044984e33d73efb52020c617dae84c75131",
+    "zh:f7d79b7c05d6da017a7d999ec34d494d96d2f8513f0aefc794b243494111ba5b",
+    "zh:fe5b68873f10aa3beda063528a4767117925d713302a2bed8529de886c1a11bd",
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# 0.4.0 (Dec 14, 2024)
+* Added GCP-managed certificate that can be disabled with `var.disable_certificate`.
+* Upgraded `ns` terraform provider to pull subdomain and fqdn from Nullstone using `ns_subdomain`.
+* Added terraform lockfile.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+lock-providers:
+	terraform providers lock -platform=linux_amd64 -platform=linux_arm64 -platform=darwin_amd64 -platform=darwin_arm64 -platform=windows_amd64

--- a/README.md
+++ b/README.md
@@ -1,16 +1,12 @@
 # autogen-gcp-subdomain
 
-Nullstone module creating a GCP Subdomain from a Nullstone-generated subdomain (e.g. `random-slug.nullstone.app`).
+Nullstone module to create a GCP-managed Subdomain hosted on Nullstone's `nullstone.app` domain.
 
-## Variables
+## Overview
 
-None
+This module creates a DNS Zone on Google Cloud DNS.
 
-## Outputs
-
-- `name: string` - The name that precedes the domain name for the created subdomain.
-- `fqdn: string` - The FQDN (fully-qualified domain name) for the created subdomain.
-- `zone_id: string` - The zone name of the GCP Managed DNS Zone for the created subdomain.
-- `nameservers: list(string)` - The list of nameservers of the GCP Managed DNS Zone for the created subdomain.
-- `domain_name: string` - The name of the root domain.
-- `domain_zone_id: string` - The zone ID of the root domain.
+By default, this module will create an SSL certificate using GCP Certificate Manager.
+This can be disabled by setting the variable `disable_certificate = true`.
+This certificate is created for Cloud CDNs and Load Balancing (most common use case).
+A certificate and certificate map are created and emitted as outputs for use to attach to a GCP Load Balancer.

--- a/cert.tf
+++ b/cert.tf
@@ -1,18 +1,11 @@
-locals {
-  purpose_to_scopes = {
-    "cdn" : "EDGE_CACHE"
-    "load-balancer" : "ALL_REGIONS"
-    "internal" : "DEFAULT"
-  }
-}
-
 module "cert" {
-  source = "nullstone-modules/sslcert/gcp"
+  source  = "nullstone-modules/sslcert/gcp"
+  version = "~> 0.1.0"
 
   enabled = !var.disable_certificate
   name    = local.resource_name
   labels  = local.labels
-  scope   = local.purpose_to_scopes[var.certificate_purpose]
+  scope   = ""
 
   subdomains = {
     (local.subdomain_dns_name) = local.subdomain_zone_id
@@ -20,6 +13,7 @@ module "cert" {
 }
 
 locals {
-  certificate_id     = module.cert.certificate_id
-  certificate_map_id = module.cert.certificate_map_id
+  certificate_id       = module.cert.certificate_id
+  certificate_map_id   = module.cert.certificate_map_id
+  certificate_map_name = module.cert.certificate_map_name
 }

--- a/cert.tf
+++ b/cert.tf
@@ -1,0 +1,25 @@
+locals {
+  purpose_to_scopes = {
+    "cdn" : "EDGE_CACHE"
+    "load-balancer" : "ALL_REGIONS"
+    "internal" : "DEFAULT"
+  }
+}
+
+module "cert" {
+  source = "nullstone-modules/sslcert/gcp"
+
+  enabled = !var.disable_certificate
+  name    = local.resource_name
+  labels  = local.labels
+  scope   = local.purpose_to_scopes[var.certificate_purpose]
+
+  subdomains = {
+    (local.subdomain_dns_name) = local.subdomain_zone_id
+  }
+}
+
+locals {
+  certificate_id     = module.cert.certificate_id
+  certificate_map_id = module.cert.certificate_map_id
+}

--- a/cert.tf
+++ b/cert.tf
@@ -8,7 +8,7 @@ module "cert" {
   scope   = ""
 
   subdomains = {
-    (local.subdomain_dns_name) = local.subdomain_zone_id
+    (local.subdomain_name) = local.subdomain_zone_id
   }
 }
 

--- a/gcp.tf
+++ b/gcp.tf
@@ -1,0 +1,5 @@
+resource "google_project_service" "dns" {
+  service                    = "dns.googleapis.com"
+  disable_dependent_services = false
+  disable_on_destroy         = false
+}

--- a/nullstone.tf
+++ b/nullstone.tf
@@ -7,3 +7,18 @@ terraform {
 }
 
 data "ns_workspace" "this" {}
+
+// Generate a random suffix to ensure uniqueness of resources
+resource "random_string" "resource_suffix" {
+  length  = 5
+  lower   = true
+  upper   = false
+  numeric = false
+  special = false
+}
+
+locals {
+  labels        = {for key, value in data.ns_workspace.this.tags : lower(key) => value}
+  block_ref     = data.ns_workspace.this.block_ref
+  resource_name = "${local.block_ref}-${random_string.resource_suffix.result}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,3 +32,8 @@ output "certificate_map_id" {
   value       = local.certificate_map_id
   description = "string ||| The ID of the Certificate Map in GCP Certificate Manager."
 }
+
+output "certificate_map_name" {
+  value       = local.certificate_map_name
+  description = "string ||| The name of the Certificate Map in GCP Certificate Manager."
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,20 +1,20 @@
 output "name" {
-  value       = local.subdomain_dns_name
+  value       = local.subdomain_name
   description = "string ||| The name of the created subdomain. (Format: '{{dns_name}}.{{domain}}')"
 }
 
 output "fqdn" {
-  value       = local.subdomain_fqdn
+  value       = local.fqdn
   description = "string ||| The FQDN (fully-qualified domain name) for the created subdomain."
 }
 
 output "zone_id" {
-  value       = google_dns_managed_zone.this.name
+  value       = local.subdomain_zone_id
   description = "string ||| The zone ID of the AWS Route53 Zone for the created subdomain."
 }
 
 output "nameservers" {
-  value       = google_dns_managed_zone.this.name_servers
+  value       = local.subdomain_nameservers
   description = "list(string) ||| The list of nameservers of the AWS Route53 Zone for the created subdomain."
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,3 +22,13 @@ output "domain_name" {
   value       = local.subdomain_domain_name
   description = "string ||| The name of the root domain."
 }
+
+output "certificate_id" {
+  value       = local.certificate_id
+  description = "string ||| The ID of the Certificate in GCP Certificate Manager."
+}
+
+output "certificate_map_id" {
+  value       = local.certificate_map_id
+  description = "string ||| The ID of the Certificate Map in GCP Certificate Manager."
+}

--- a/subdomain.tf
+++ b/subdomain.tf
@@ -1,3 +1,4 @@
+// TODO: Upgrade ns provider and use datasource to retrieve dns_name and fqdn from Nullstone APIs
 resource "ns_autogen_subdomain" "autogen_subdomain" {
   subdomain_id = data.ns_workspace.this.block_id
   env_id       = data.ns_workspace.this.env_id
@@ -5,8 +6,9 @@ resource "ns_autogen_subdomain" "autogen_subdomain" {
 
 locals {
   subdomain_domain_name = ns_autogen_subdomain.autogen_subdomain.domain_name
-  subdomain_dns_name    = trimsuffix(ns_autogen_subdomain.autogen_subdomain.fqdn, ".")
+  subdomain_dns_name = trimsuffix(ns_autogen_subdomain.autogen_subdomain.fqdn, ".")
   subdomain_fqdn        = ns_autogen_subdomain.autogen_subdomain.fqdn
+  subdomain_zone_id     = google_dns_managed_zone.this.name
 }
 
 resource "google_project_service" "dns" {

--- a/subdomain.tf
+++ b/subdomain.tf
@@ -1,28 +1,30 @@
-// TODO: Upgrade ns provider and use datasource to retrieve dns_name and fqdn from Nullstone APIs
-resource "ns_autogen_subdomain" "autogen_subdomain" {
-  subdomain_id = data.ns_workspace.this.block_id
-  env_id       = data.ns_workspace.this.env_id
+data "ns_subdomain" "this" {
+  stack_id = data.ns_workspace.this.stack_id
+  block_id = data.ns_workspace.this.block_id
+  env_id   = data.ns_workspace.this.env_id
 }
 
 locals {
-  subdomain_domain_name = ns_autogen_subdomain.autogen_subdomain.domain_name
-  subdomain_dns_name = trimsuffix(ns_autogen_subdomain.autogen_subdomain.fqdn, ".")
-  subdomain_fqdn        = ns_autogen_subdomain.autogen_subdomain.fqdn
-  subdomain_zone_id     = google_dns_managed_zone.this.name
-}
-
-resource "google_project_service" "dns" {
-  service                    = "dns.googleapis.com"
-  disable_dependent_services = false
-  disable_on_destroy         = false
+  fqdn                  = data.ns_subdomain.this.fqdn
+  subdomain_domain_name = data.ns_subdomain.this.domain_name
 }
 
 resource "google_dns_managed_zone" "this" {
   name     = data.ns_workspace.this.block_ref
-  dns_name = ns_autogen_subdomain.autogen_subdomain.fqdn
+  dns_name = local.fqdn
   labels   = { for k, v in data.ns_workspace.this.tags : lower(k) => lower(v) }
 
   depends_on = [google_project_service.dns]
+}
+
+locals {
+  // zone_id refers to google_dns_managed_zone.this.name; however, we need this variable to wait on the resource to be created
+  // We're going to take google_dns_managed_zone.this.id and parse out the name (since id is computed during creation)
+  // Format: projects/{{project}}/managedZones/{{name}}
+  subdomain_zone_id = regex("^projects/[^/]+/managedZones/([^/]+)$", google_dns_managed_zone.this.id)[0]
+
+  subdomain_name        = google_dns_managed_zone.this.dns_name
+  subdomain_nameservers = [for ns in google_dns_managed_zone.this.name_servers : trimsuffix(ns, ".")]
 }
 
 resource "ns_autogen_subdomain_delegation" "to_gcp" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,23 @@
+variable "disable_certificate" {
+  type        = bool
+  default     = false
+  description = "Specify true to disable SSL certificate creation"
+}
+
+variable "certificate_purpose" {
+  type        = string
+  default     = "load-balancer"
+  description = <<EOF
+This enables creating a GCP-managed SSL certificate in Certificate Manager.
+The purpose allows you to configure the certificate for the device
+Available choices: "cdn" for Cloud CDN, "load-balancer" for Internet Load Balancers, or "internal"
+EOF
+
+  validation {
+    condition     = contains(["cdn", "load-balancer", "internal"], var.certificate_purpose)
+    error_message = <<EOF
+The purpose must be one of 'cdn', 'load-balancer', or 'internal'.
+This is meant to create a certificate that is specific to the ingress device that it is attached.
+EOF
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -3,21 +3,3 @@ variable "disable_certificate" {
   default     = false
   description = "Specify true to disable SSL certificate creation"
 }
-
-variable "certificate_purpose" {
-  type        = string
-  default     = "load-balancer"
-  description = <<EOF
-This enables creating a GCP-managed SSL certificate in Certificate Manager.
-The purpose allows you to configure the certificate for the device
-Available choices: "cdn" for Cloud CDN, "load-balancer" for Internet Load Balancers, or "internal"
-EOF
-
-  validation {
-    condition     = contains(["cdn", "load-balancer", "internal"], var.certificate_purpose)
-    error_message = <<EOF
-The purpose must be one of 'cdn', 'load-balancer', or 'internal'.
-This is meant to create a certificate that is specific to the ingress device that it is attached.
-EOF
-  }
-}


### PR DESCRIPTION
- Added SSL certificate
- Upgrade `ns` terraform provider
- Instead of creating autogen subdomain, this module now pulls the subdomain info (fqdn, dns_name) from Nullstone
- Added terraform lockfile